### PR TITLE
Enabled the ability to start app and db using docker compose

### DIFF
--- a/App.Dockerfile
+++ b/App.Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
+WORKDIR /app
+
+# Copy csproj and restore as distinct layers
+COPY *.sln .
+COPY src/NewTodo/*.csproj ./src/NewTodo/
+COPY NewTodo.DbMigration/*.csproj ./NewTodo.DbMigration/
+COPY NewTodo.Domain/*.csproj ./NewTodo.Domain/
+COPY NewTodo.IntegrationTest/*.csproj ./NewTodo.IntegrationTest/
+COPY NewTodo.Test/*.csproj ./NewTodo.Test/
+COPY runTest.sh runTest.sh
+
+RUN chmod +x runTest.sh
+RUN dotnet restore
+
+# Copy everything else and build
+COPY src/NewTodo/. ./src/NewTodo/
+COPY NewTodo.DbMigration/. ./NewTodo.DbMigration/
+COPY NewTodo.Domain/. ./NewTodo.Domain/
+COPY NewTodo.IntegrationTest/. ./NewTodo.IntegrationTest/
+COPY NewTodo.Test/. ./NewTodo.Test/
+
+#Publish
+WORKDIR /app/src/NewTodo
+RUN dotnet publish -c Release -o out
+
+# Build runtime image
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
+WORKDIR /app
+COPY --from=build-env /app/src/NewTodo/out ./
+ENTRYPOINT ["dotnet", "NewTodo.dll"]

--- a/Db.Dockerfile
+++ b/Db.Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/mssql/server:2019-latest
+
+USER root
+
+COPY NewTodo.DbMigration/CreateDB.sql CreateDB.sql
+COPY dbInitial.sh dbInitial.sh
+COPY entryPoint.sh entryPoint.sh
+
+RUN chmod +x dbInitial.sh entryPoint.sh
+
+CMD /bin/bash ./entryPoint.sh

--- a/dbInitial.sh
+++ b/dbInitial.sh
@@ -1,0 +1,12 @@
+for i in {1..50};
+do
+    /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password@12345 -d master -i CreateDB.sql
+    if [ $? -eq 0 ]
+    then
+        echo "CreateDB.sql completed"
+        break
+    else
+        echo "not ready yet..."
+        sleep 1
+    fi
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  newtodo-db:
+    image: newtodo-sqlserver
+    environment: 
+      ACCEPT_EULA: "Y"
+      SA_PASSWORD: "Password@12345"
+    ports:
+      - "1433:1433"
+  newtodo-app:
+    build: 
+      context: ./
+      dockerfile: App.Dockerfile
+    environment: 
+      SQLCONNSTR_DefaultConnection: "server=newtodo-db;uid=sa;pwd=Password@12345;database=TodoDb"
+    ports:
+      - "8080:80"
+    depends_on:
+      - newtodo-db

--- a/entryPoint.sh
+++ b/entryPoint.sh
@@ -1,0 +1,1 @@
+./dbInitial.sh & /opt/mssql/bin/sqlservr


### PR DESCRIPTION
App.Dockerfile: Docker configuration for .net core app
Db.Dockefile: Docker configuration for sql server and database, table creation
dbInital.sh and entryPoint.sh: Shell scripts used for db initialisation.
docker-compose.yml: compose app and db.

Now, the app is able to be started and connect to db with the single command:
docker-compose up